### PR TITLE
Potential fix for code scanning alert no. 12: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "nodemailer": "^6.10.0",
     "nodemon": "^3.1.9",
     "stripe": "^17.7.0",
-    "validator": "^13.12.0"
+    "validator": "^13.12.0",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/backend/routes/orderRoute.js
+++ b/backend/routes/orderRoute.js
@@ -1,4 +1,5 @@
 import express from "express";
+import RateLimit from "express-rate-limit";
 import {
   allOrders,
   placeOrder,
@@ -12,6 +13,12 @@ import userAuth from "../middleware/userAuth.js";
 
 const orderRouter = express.Router();
 
+// Rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
 //admin features
 orderRouter.post("/list", adminAuth, allOrders);
 orderRouter.post("/status", adminAuth, updateStatus);
@@ -24,6 +31,6 @@ orderRouter.post("/stripe", userAuth, placeOrderStripe);
 orderRouter.post("/userorders", userAuth, userOrders);
 
 //verifyPayment
-orderRouter.post("/verifyStripe", userAuth, verifyStripe);
+orderRouter.post("/verifyStripe", userAuth, limiter, verifyStripe);
 
 export default orderRouter;


### PR DESCRIPTION
Potential fix for [https://github.com/Learnathon-By-Geeky-Solutions/codeclusters/security/code-scanning/12](https://github.com/Learnathon-By-Geeky-Solutions/codeclusters/security/code-scanning/12)

To fix the problem, we need to introduce rate limiting to the `verifyStripe` route handler to prevent potential denial-of-service attacks. The best way to achieve this is by using the `express-rate-limit` middleware, which allows us to set a maximum number of requests per time window.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `backend/routes/orderRoute.js` file.
3. Create a rate limiter with appropriate settings.
4. Apply the rate limiter to the `verifyStripe` route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
